### PR TITLE
styles(landing-page): fix container width in large screens

### DIFF
--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -85,3 +85,9 @@
     max-width: 1440px;
   }
 }
+
+@media (min-width: 1440px) {
+  .container {
+    max-width: 1440px;
+  }
+}

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -75,15 +75,15 @@
 .buttons .getStartedButton {
   flex-direction: row;
   font-size: 1.125rem;
+}
 
-  &:after {
-    content: 'east';
-    font-family: Material Symbols Outlined;
-    margin-left: 0.5rem;
-    pointer-events: none;
-    position: relative;
-    top: 1px;
-  }
+.buttons .getStartedButton:after {
+  content: 'east';
+  font-family: Material Symbols Outlined;
+  margin-left: 0.5rem;
+  pointer-events: none;
+  position: relative;
+  top: 1px;
 }
 
 @media screen and (min-width: 768px) and (max-width: 1024px) {
@@ -141,5 +141,11 @@
 
   .buttons {
     margin-top: 2.5rem;
+  }
+}
+
+@media (min-width: 1440px) {
+  .container {
+    max-width: 1440px;
   }
 }


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
Fixed the issue of container width of landing page not occupying 1440px in large screens.

### What's included?

<!-- List features included in this PR -->

- Container width set to 1440px in large screens

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run build` still works.
