### PR TITLE
styles(admonition): fix caution admonition styles

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -22,39 +22,54 @@
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 
-  --ifm-color-secondary: #00233C;
+  --ifm-color-secondary: #00233c;
   --ifm-color-success: var(--cv-theme-light-colors-positive);
   --ifm-color-info: var(--cv-theme-light-colors-neutral);
   --ifm-color-warning: var(--cv-theme-light-colors-caution);
   --ifm-color-danger: var(--cv-theme-light-colors-negatvive);
 
   --ifm-background-surface-color: var(--cv-theme-light-colors-surface);
-  --ifm-color-secondary-contrast-background: var(--cv-theme-light-colors-surface-variant);
-  --ifm-color-secondary-contrast-foreground: var(--cv-theme-light-colors-on-surface-container);
+  --ifm-color-secondary-contrast-background: var(
+    --cv-theme-light-colors-surface-variant
+  );
+  --ifm-color-secondary-contrast-foreground: var(
+    --cv-theme-light-colors-on-surface-container
+  );
 
   --ifm-color-success-dark: var(--cv-theme-light-colors-positive);
-  --ifm-color-success-contrast-background: var(--cv-theme-light-colors-positive-container);
-  --ifm-color-success-contrast-foreground: var(--cv-theme-light-colors-on-positive-container);
+  --ifm-color-success-contrast-background: var(--cv-theme-secondary);
+  --ifm-color-success-contrast-foreground: var(--cv-theme-on-surface);
 
   --ifm-color-danger-dark: var(--cv-theme-light-colors-negative);
-  --ifm-color-danger-contrast-background: var(--cv-theme-light-colors-negative-container);
-  --ifm-color-danger-contrast-foreground: var(--cv-theme-light-colors-on-negative-container);
+  --ifm-color-danger-contrast-background: var(
+    --cv-theme-light-colors-negative-container
+  );
+  --ifm-color-danger-contrast-foreground: var(
+    --cv-theme-light-colors-on-negative-container
+  );
 
   --ifm-color-warning-dark: var(--cv-theme-light-colors-caution);
-  --ifm-color-warning-contrast-background: var(--cv-theme-light-colors-caution-container);
-  --ifm-color-warning-contrast-foreground: var(--cv-theme-light-colors-on-caution-container);
+  --ifm-color-warning-contrast-background: var(--cv-theme-caution);
+  --ifm-color-warning-contrast-foreground: var(--cv-theme-on-surface);
 
-  --ifm-color-info-contrast-background: var(--cv-theme-light-colors-primary-container);
-  --ifm-color-info-contrast-foreground: var(--cv-theme-light-colors-on-primary-container);
+  --ifm-color-info-contrast-background: var(
+    --cv-theme-light-colors-primary-container
+  );
+  --ifm-color-info-contrast-foreground: var(
+    --cv-theme-light-colors-on-primary-container
+  );
   --ifm-color-info-dark: var(--cv-theme-light-colors-primary);
   --ifm-breadcrumb-item-background-active: none;
   --ifm-breadcrumb-color-active: #5e7484;
   --mdc-theme-surface-canvas: var(--cv-theme-surface-container);
   --ifm-toc-link-color: var(--Gray-700, #333a3e);
+  --ifm-heading-font-family: 'Inter', sans-serif;
+  --ifm-heading-color: #00233c;
+  --ifm-heading-font-weight: 600;
 }
 
 body {
-  font-family: "Inter", sans-serif;
+  font-family: 'Inter', sans-serif;
   font-size: 16px;
 }
 
@@ -86,10 +101,10 @@ aside.theme-doc-sidebar-container {
 }
 
 .markdown h1:first-child {
-  color: #00233C;
+  color: #00233c;
 
   /* Desktop/H1 */
-  font-family: "Inter", sans-serif;
+  font-family: 'Inter', sans-serif;
   font-size: 54px;
   font-style: normal;
   font-weight: 300;
@@ -99,19 +114,25 @@ aside.theme-doc-sidebar-container {
 }
 
 .markdown h2 {
-  color: #00233C;
+  color: #00233c;
   font-feature-settings: 'clig' off, 'liga' off;
-  font-family: "Inter", sans-serif;
+  font-family: 'Inter', sans-serif;
   font-size: 24px;
   font-style: normal;
   font-weight: 600;
-  line-height: 36px; /* 150% */
+  line-height: 36px;
+}
+
+.markdown h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 28px;
 }
 
 .markdown p {
-  color: var(--Gray-700, #333A3E);
+  color: var(--Gray-700, #333a3e);
   font-feature-settings: 'clig' off, 'liga' off;
-  font-family: "Inter", sans-serif;
+  font-family: 'Inter', sans-serif;
   font-size: 16px;
   font-style: normal;
   font-weight: 400;
@@ -327,6 +348,17 @@ html.plugin-search-algolia .main-wrapper .container {
   transform-origin: 0 50%;
   transition: transform 0.25s ease-in-out;
   width: 100%;
+}
+
+.theme-admonition.alert--secondary,
+.theme-admonition.alert--secondary p {
+  color: var(--cv-theme-on-surface);
+}
+
+.theme-admonition.alert--warning,
+.theme-admonition.alert--success {
+  --ifm-alert-foreground-color: var(--cv-theme-on-secondary);
+  --ifm-alert-border-color: var(--cv-theme-on-secondary);
 }
 
 @media screen and (max-width: 767px) {

--- a/src/theme/Admonition/Layout/index.tsx
+++ b/src/theme/Admonition/Layout/index.tsx
@@ -45,11 +45,7 @@ export default function AdmonitionLayout(props: Props): JSX.Element {
   return (
     <AdmonitionContainer
       type={type}
-      className={clsx(
-        className,
-        styles.admonitionWrapper,
-        type === 'tip' ? styles.admonitionTip : ''
-      )}
+      className={clsx(className, styles.admonitionWrapper)}
     >
       <span className={styles.admonitionIcon}>{icon}</span>
       <span className={styles.admonitionContentWrapper}>

--- a/src/theme/Admonition/Layout/styles.module.css
+++ b/src/theme/Admonition/Layout/styles.module.css
@@ -28,10 +28,6 @@
   fill: var(--ifm-alert-foreground-color);
 }
 
-.admonitionIcon:not(.admonitionTip .admonitionIcon) {
-  --ifm-alert-foreground-color: #00000099;
-}
-
 .admonitionContentWrapper {
   padding: 0.625rem;
 }
@@ -42,12 +38,8 @@
 
 .admonitionContent,
 .admonitionContent p {
-  color: var(--cv-theme-on-surface);
   font-size: 0.875rem;
-}
-
-.admonitionTip p {
-  color: var(--cv-theme-on-secondary);
+  color: var(--ifm-alert-foreground-color);
 }
 
 .admonitionWrapper {
@@ -60,11 +52,4 @@
 
 .admonitionWrapper {
   text-underline-offset: 2px;
-}
-
-.admonitionTip {
-  --ifm-alert-background-color: var(--cv-theme-secondary);
-  --ifm-alert-foreground-color: var(--cv-theme-on-secondary);
-  --ifm-alert-border-color: var(--cv-theme-on-secondary);
-  --ifm-code-background: var(--cv-theme-on-secondary-container-8);
 }


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
- Fix caution admonition colors.
- Fix h3 styles.

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="682" alt="Screenshot 2024-05-15 at 4 10 10 PM" src="https://github.com/Teradata/ai-unlimited-docs/assets/148156994/a35fc409-b11b-4cb3-aac8-80a172f3a19e">
<img width="690" alt="Screenshot 2024-05-15 at 4 11 03 PM" src="https://github.com/Teradata/ai-unlimited-docs/assets/148156994/03cb0f64-a71a-4ecc-8d7a-4be9a45365e8">
