### PR TITLE
Fix/g tag policy

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,7 +37,7 @@ const config = {
       attributes: {
         'http-equiv': 'Content-Security-Policy',
         content:
-          "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: https://avatars.githubusercontent.com https://github.com https://kit.fontawesome.com/ https://ka-f.fontawesome.com/ https://fonts.googleapis.com/ https://fonts.gstatic.com/ https://*.algolia.net/;",
+          "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: https://avatars.githubusercontent.com https://github.com https://kit.fontawesome.com/ https://ka-f.fontawesome.com/ https://fonts.googleapis.com/ https://fonts.gstatic.com/ https://www.google-analytics.com/ https://*.algolia.net/;",
       },
     },
     {
@@ -87,6 +87,13 @@ const config = {
          * Path to data on filesystem relative to site dir.
          */
         path: './releases',
+      },
+    ],
+    [
+      '@docusaurus/plugin-google-gtag',
+      {
+        trackingID: 'G-RDK4Y0RE7S',
+        anonymizeIP: true,
       },
     ],
   ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,13 +89,6 @@ const config = {
         path: './releases',
       },
     ],
-    [
-      '@docusaurus/plugin-google-gtag',
-      {
-        trackingID: 'G-RDK4Y0RE7S',
-        anonymizeIP: true,
-      },
-    ],
   ],
 
   presets: [


### PR DESCRIPTION
adding `google-analytics.com` domain to the allowed URLs for the content policy