### PR TITLE
feat(header-cta): add a cta button in the header

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -5,6 +5,9 @@
   "header.getting_started": {
     "message": "Getting started"
   },
+  "header.actions.free_demo": {
+    "message": "Start free demo"
+  },
   "header.docs": {
     "message": "Docs"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@docusaurus/preset-classic": "3.2.0",
         "@docusaurus/theme-mermaid": "3.2.0",
         "@mdx-js/react": "^3.0.0",
-        "@teradata-web/react-components": "^1.0.4",
+        "@teradata-web/react-components": "^1.3.0",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^18.0.0",
@@ -4562,9 +4562,9 @@
       }
     },
     "node_modules/@teradata-web/react-components": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@teradata-web/react-components/-/react-components-1.0.4.tgz",
-      "integrity": "sha512-4ULyfETKLflINbnZIcDJfpeb0j+A/B5N3RRdvbKC6HtlMn6P9AI3wh68udLen5l6L2T5oOjJyfnfRzkhc7Bztw=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@teradata-web/react-components/-/react-components-1.3.0.tgz",
+      "integrity": "sha512-EmFl/KZ/wxfoK+iLnwBQBTRbpb/VGMhapiPSIyJyc6l1W0bz+F6ZsGtNDwiDBbFBR+yCt1ec34a0rmfaA9BqVw=="
     },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
@@ -5592,11 +5592,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -8089,9 +8089,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@docusaurus/preset-classic": "3.2.0",
     "@docusaurus/theme-mermaid": "3.2.0",
     "@mdx-js/react": "^3.0.0",
-    "@teradata-web/react-components": "^1.0.4",
+    "@teradata-web/react-components": "^1.3.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",

--- a/src/theme/Navbar/index.tsx
+++ b/src/theme/Navbar/index.tsx
@@ -1,11 +1,17 @@
-import React, { useEffect, useState } from 'react';
-import { Header, Language, NavListItem } from '@teradata-web/react-components';
+import React, { ReactElement, useEffect, useState } from 'react';
+import {
+  Button,
+  Header,
+  HeaderAction,
+  Language,
+  NavListItem,
+} from '@teradata-web/react-components';
 import { useThemeConfig } from '@docusaurus/theme-common';
 import { useNavbarSecondaryMenu } from '@docusaurus/theme-common/internal';
 import { translate } from '@docusaurus/Translate';
 import SearchBar from '../SearchBar';
 import { ThemeConfig } from '@docusaurus/types';
-
+import Link from '@docusaurus/Link';
 
 function translateNavItems(navItems: NavListItem[]): NavListItem[] {
   return navItems.map((item) => {
@@ -31,6 +37,22 @@ export default function Navbar() {
 
   const translatedTitle = translate({ message: title });
   const translatedNavItems = translateNavItems(nestedNavItems);
+
+  const headerActions: HeaderAction[] = [
+    { actionElement: <SearchBar />, type: 'search' },
+    {
+      actionElement: (
+        <Link to="https://www.teradata.com/getting-started/demos/clearscape-analytics">
+          <Button
+            label={translate({ message: 'header.actions.free_demo' })}
+            icon="fa-solid fa-arrow-right-long"
+            trailingIcon={true}
+          />
+        </Link>
+      ),
+      type: 'button',
+    },
+  ];
 
   const secondaryMenuDetails = {
     menuElement: useNavbarSecondaryMenu().content as JSX.Element,
@@ -92,7 +114,7 @@ export default function Navbar() {
       key={defaultLang}
       navItems={translatedNavItems}
       title={translatedTitle}
-      headerActions={[{ actionElement: <SearchBar />, type: 'search' }]}
+      headerActions={headerActions}
       languages={languages}
       onLanguageChange={handleLanguageChange}
       selectedLanguage={defaultLang}


### PR DESCRIPTION
Add a new CTA (Start free demo) to the header to promote ClearScape Analytics Experience registrations. 

### Desktop
<img width="1263" alt="Screenshot 2024-06-14 at 2 22 18 PM" src="https://github.com/Teradata/ai-unlimited-docs/assets/148156994/54149538-b1c7-4e81-906b-91efdab988d8">

### Mobile nav
<img width="701" alt="Screenshot 2024-06-14 at 2 25 01 PM" src="https://github.com/Teradata/ai-unlimited-docs/assets/148156994/6a3d77ed-4ed6-458d-97fc-199cf365d186">

