### PR TITLE
feat(translations): add missing translations in home page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,8 +12,8 @@ const projectName = 'ai-unlimited-docs';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'Teradata AI Unlimited Documentation',
-  tagline: 'A scalable, on-demand compute engine in the cloud.',
+  title: 'home_page.title',
+  tagline: 'home_page.tagline',
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -203,13 +203,77 @@
   "footer.platform_ai_ml": {
     "message": "Drive ROI with Trusted AI today"
   },
+
+  "feature.title.analytic_functions": {
+    "message": "Analytic functions"
+  },
+  "feature.title.explore_data": {
+    "message": "Explore and analyze data"
+  },
+  "feature.title.faq": {
+    "message": "FAQ"
+  },
+  "feature.title.glossary": {
+    "message": "Glossary"
+  },
+  "feature.title.manage_projects": {
+    "message": "Manage projects"
+  },
+  "feature.title.other_resources": {
+    "message": "Other resources"
+  },
+  "feature.title.sample_use_cases": {
+    "message": "Sample use cases"
+  },
+  "feature.title.whats_new": {
+    "message": "What's new"
+  },
+  "feature.description.analytic_functions": {
+    "message": "Browse and search ClearScape™ functions to use in projects"
+  },
+  "feature.description.explore_data": {
+    "message": "Learn about AI Unlimited projects and create your first one"
+  },
+  "feature.description.faq": {
+    "message": "Get answers to your questions"
+  },
+  "feature.description.get_started": {
+    "message": "See what AI Unlimited includes, prerequisites you need, and installation how-tos"
+  },
+  "feature.description.glossary": {
+    "message": "Look up AI Unlimited terminology"
+  },
+  "feature.description.manage_projects": {
+    "message": "Learn how to manage projects or change AI Unlimited settings"
+  },
+  "feature.description.other_resources": {
+    "message": "Find additional installation resources, and more"
+  },
+  "feature.description.sample_use_cases": {
+    "message": "Explore ways to use AI Unlimited to experiment and innovate"
+  },
+  "feature.description.whats_new": {
+    "message": "Watch for new features and updates—and see what's coming"
+  },
+  "home_page.categories": {
+    "message": "Categories"
+  },
   "home_page.featured_event": {
     "message": "Featured event"
+  },
+  "home_page.get_started": {
+    "message": "Get started"
   },
   "home_page.possible_banner_title": {
     "message": "If you imagine it, envision it, create it... Teradata makes it Possible. Join us."
   },
   "home_page.register_now": {
     "message": "Register now"
+  },
+  "home_page.tagline": {
+    "message": "A scalable, on-demand compute engine in the cloud."
+  },
+  "home_page.title": {
+    "message": "Teradata AI Unlimited Documentation"
   }
 }

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -255,6 +255,9 @@
   "feature.description.whats_new": {
     "message": "Watch for new features and updates—and see what's coming"
   },
+  "home_page.hero_img_description": {
+    "message": "A woman smiling and holding a laptop, standing in a modern office environment with abstract geometric shapes in the background."
+  },
   "home_page.categories": {
     "message": "Categories"
   },

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -278,5 +278,11 @@
   },
   "home_page.title": {
     "message": "Teradata AI Unlimited Documentation"
+  },
+  "sidenav.title": {
+    "message": "Docs"
+  },
+  "sidenav.title_description": {
+    "message": "The title for the sidebar in mobile view"
   }
 }

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -6,52 +6,51 @@ import PossibleImageUrl from '@site/static/img/possible_img.webp';
 import { Card, Typography } from '@teradata-web/react-components';
 import { translate } from '@docusaurus/Translate';
 
-const FeatureTitle = 'Categories';
+const FeatureTitle = 'home_page.categories';
 const FeatureList = [
   {
-    title: 'Get started',
-    description:
-      'See what AI Unlimited includes, prerequisites you need, and installation how-tos',
+    title: 'home_page.get_started',
+    description: 'feature.description.get_started',
     href: '/docs/install-ai-unlimited/',
   },
   {
-    title: `Sample use cases`,
-    description: 'Explore ways to use AI Unlimited to experiment and innovate',
+    title: 'feature.title.sample_use_cases',
+    description: 'feature.description.sample_use_cases',
     href: '/docs/explore-and-analyze-data/use-cases/',
   },
   {
-    title: `What's new`,
-    description: 'Watch for new features and updates—and see what’s coming',
+    title: `feature.title.whats_new`,
+    description: 'feature.description.whats_new',
     href: '/docs/whats-new/',
   },
   {
-    title: 'Explore and analyze data',
-    description: 'Learn about AI Unlimited projects and create your first one',
+    title: 'feature.title.explore_data',
+    description: 'feature.description.explore_data',
     href: '/docs/explore-and-analyze-data/',
   },
   {
-    title: `Analytic functions`,
-    description: 'Browse and search ClearScape™ functions to use in projects',
+    title: `feature.title.analytic_functions`,
+    description: 'feature.description.analytic_functions',
     href: 'https://docs.teradata.com/access/sources/dita/topic?dita:mapPath=phg1621910019905.ditamap&dita:ditavalPath=pny1626732985837.ditaval&dita:topicPath=gma1702668333653.dita',
   },
   {
-    title: 'Manage projects',
-    description: 'Learn how to manage projects or change AI Unlimited settings',
+    title: 'feature.title.manage_projects',
+    description: 'feature.description.manage_projects',
     href: '/docs/manage-ai-unlimited/',
   },
   {
-    title: 'Other resources',
-    description: 'Find additional installation resources, and more',
+    title: 'feature.title.other_resources',
+    description: 'feature.description.other_resources',
     href: '/docs/resources/',
   },
   {
-    title: 'FAQ',
-    description: 'Get answers to your questions',
+    title: 'feature.title.faq',
+    description: 'feature.description.faq',
     href: '/docs/faq/',
   },
   {
-    title: 'Glossary',
-    description: 'Look up AI Unlimited terminology',
+    title: 'feature.title.glossary',
+    description: 'feature.description.glossary',
     href: '/docs/glossary/',
   },
 ];
@@ -84,8 +83,8 @@ function Feature({ title, description, href }) {
   return (
     <Link to={href} className={clsx('col col--4', styles.col)}>
       <div className={clsx('doc-card', styles.card)}>
-        <Heading as="h3">{title}</Heading>
-        {description && <p>{description}</p>}
+        <Heading as="h3">{translate({ message: title })}</Heading>
+        {description && <p>{translate({ message: description })}</p>}
       </div>
     </Link>
   );
@@ -115,7 +114,7 @@ export default function HomepageFeatures() {
       </section>
       <section className={styles.features}>
         <div className={clsx('container', styles.container)}>
-          <h2>{FeatureTitle}</h2>
+          <h2>{translate({ message: FeatureTitle })}</h2>
           <div className={clsx('row', styles.row)}>
             {FeatureList.map((props, idx) => (
               <Feature key={idx} {...props} />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -39,7 +39,7 @@ function HomepageHeader() {
           <img
             src={HeroImageUrl}
             width="498"
-            alt="A woman smiling and holding a laptop, standing in a modern office environment with abstract geometric shapes in the background."
+            alt={translate({ message: 'home_page.hero_img_description' })}
           />
           <div className={styles.heroBlur}></div>
         </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,7 +4,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import HeroImageUrl from '@site/static/img/hero.webp';
-import Translate from '@docusaurus/Translate';
+import Translate, { translate } from '@docusaurus/Translate';
 import Heading from '@theme/Heading';
 import styles from './index.module.css';
 function HomepageHeader() {
@@ -14,10 +14,12 @@ function HomepageHeader() {
       <div className={clsx('container', styles.container)}>
         <div className="">
           <Heading as="h1" className="hero__title">
-            {siteConfig.title}
+            {translate({ message: siteConfig.title })}
           </Heading>
           <p className="hero__subtitle">
-            <Translate id="theme.tagline">{siteConfig.tagline}</Translate>
+            <Translate id="theme.tagline">
+              {translate({ message: siteConfig.tagline })}
+            </Translate>
           </p>
           <div className={styles.buttons}>
             <Link
@@ -27,12 +29,18 @@ function HomepageHeader() {
               )}
               to="/docs/install-ai-unlimited"
             >
-              <Translate id="theme.button">Get Started</Translate>
+              <Translate id="theme.button">
+                {translate({ message: 'home_page.get_started' })}
+              </Translate>
             </Link>
           </div>
         </div>
         <div className={styles.heroImage}>
-          <img src={HeroImageUrl} width="498" alt="A woman smiling and holding a laptop, standing in a modern office environment with abstract geometric shapes in the background." />
+          <img
+            src={HeroImageUrl}
+            width="498"
+            alt="A woman smiling and holding a laptop, standing in a modern office environment with abstract geometric shapes in the background."
+          />
           <div className={styles.heroBlur}></div>
         </div>
       </div>
@@ -43,9 +51,7 @@ function HomepageHeader() {
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
   return (
-    <Layout
-      description={siteConfig.tagline}
-    >
+    <Layout description={translate({ message: siteConfig.tagline })}>
       <HomepageHeader />
       <main className={styles.features}>
         <HomepageFeatures />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,9 +17,7 @@ function HomepageHeader() {
             {translate({ message: siteConfig.title })}
           </Heading>
           <p className="hero__subtitle">
-            <Translate id="theme.tagline">
-              {translate({ message: siteConfig.tagline })}
-            </Translate>
+            <Translate id={siteConfig.tagline} />
           </p>
           <div className={styles.buttons}>
             <Link
@@ -29,9 +27,7 @@ function HomepageHeader() {
               )}
               to="/docs/install-ai-unlimited"
             >
-              <Translate id="theme.button">
-                {translate({ message: 'home_page.get_started' })}
-              </Translate>
+              <Translate id="home_page.get_started" />
             </Link>
           </div>
         </div>

--- a/src/theme/Navbar/index.tsx
+++ b/src/theme/Navbar/index.tsx
@@ -57,9 +57,8 @@ export default function Navbar() {
   const secondaryMenuDetails = {
     menuElement: useNavbarSecondaryMenu().content as JSX.Element,
     title: translate({
-      id: 'theme.docs.sidebar.title',
-      message: 'Docs',
-      description: 'The title for the sidebar in mobile view',
+      message: 'sidenav.title',
+      description: 'sidenav.title_description',
     }),
   };
 


### PR DESCRIPTION
- Add missing translations in ai-unlimited for below sections

<img width="546" alt="Screenshot 2024-07-30 at 11 44 48 AM" src="https://github.com/user-attachments/assets/5c28a0d2-caa0-4bf6-9880-c765d7e90d65">
<img width="1285" alt="Screenshot 2024-07-30 at 11 44 58 AM" src="https://github.com/user-attachments/assets/bf491aac-fe74-449f-8a99-93ffd8ae9a30">
