### PR TITLE
fix(translations): add workaround for site title and tagline translations

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,10 +10,35 @@ import tailwindPlugin from './plugins/tailwind-config.cjs';
 const baseUrl = '/ai-unlimited-docs';
 const projectName = 'ai-unlimited-docs';
 
+const getCurrentLocale = () => process.env.DOCUSAURUS_CURRENT_LOCALE ?? 'en';
+
+/**
+ * This is a workaround for translations of site title and tagline.
+ * Docusaurus does not support translations for title and tagline in site config yet.
+ * Refer to: https://github.com/facebook/docusaurus/issues/4542 for details
+ */
+const getSiteTagline = () => {
+  // Add translations for the tagline in the switch case
+  switch (getCurrentLocale()) {
+    case 'en':
+    default:
+      return 'A scalable, on-demand compute engine in the cloud.';
+  }
+};
+
+const getSiteTitle = () => {
+  // Add translations for the title in the switch case
+  switch (getCurrentLocale()) {
+    case 'en':
+    default:
+      return 'Teradata AI Unlimited Documentation';
+  }
+};
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'home_page.title',
-  tagline: 'home_page.tagline',
+  title: getSiteTitle(),
+  tagline: getSiteTagline(),
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,11 +14,9 @@ function HomepageHeader() {
       <div className={clsx('container', styles.container)}>
         <div className="">
           <Heading as="h1" className="hero__title">
-            {translate({ message: siteConfig.title })}
+            {siteConfig.title}
           </Heading>
-          <p className="hero__subtitle">
-            <Translate id={siteConfig.tagline} />
-          </p>
+          <p className="hero__subtitle">{siteConfig.tagline}</p>
           <div className={styles.buttons}>
             <Link
               className={clsx(
@@ -47,7 +45,7 @@ function HomepageHeader() {
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
   return (
-    <Layout description={translate({ message: siteConfig.tagline })}>
+    <Layout description={siteConfig.tagline}>
       <HomepageHeader />
       <main className={styles.features}>
         <HomepageFeatures />


### PR DESCRIPTION
- Docusaurus currently does not support translations for the `title` and `tagline` properties in the `siteConfig`. For more information, you can refer to this [GitHub Issue](https://github.com/facebook/docusaurus/issues/4542). 
- A workaround has been proposed to enable translation of these properties.

<img width="871" alt="Screenshot 2024-07-31 at 5 26 50 PM" src="https://github.com/user-attachments/assets/25955ae1-5cab-4bed-8a78-555c6bbb4537">
