### PR TITLE
fix(styles): remove with in middle column

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -383,6 +383,7 @@ html.plugin-search-algolia .main-wrapper .container {
   }
 }
 
+
 @media screen and (min-width: 1025px) {
   html:not(.plugin-pages) .main-wrapper {
     padding: 0 6.625rem 0;
@@ -399,6 +400,11 @@ html.plugin-search-algolia .main-wrapper .container {
 
   html:not(.plugin-pages).plugin-search-algolia .main-wrapper .container {
     padding: 0 6.625rem;
+  }
+}
+@media screen and (min-width: 1025px) and (max-width: 1125px) {
+  html:not(.plugin-pages) .main-wrapper {
+    padding: 0 1.63rem;
   }
 }
 


### PR DESCRIPTION
## Description

On the iPad Pro 13” the layout is looking a bit off. We should look at adjusting this to reduce the padding on the outside of the page as the current layout shows the left column and the middle content at nearly the same width.

### What's included?

<!-- List features included in this PR -->

- One
- Two
- Three
#### General Tests for Every PR

Please make sure your PR adheres to the following requirements:

- [ ] `npm run start` still works.
- [ ] `npm run build` still works.
- [ ] Code adheres to project style guidelines (e.g., linting, formatting).
- [ ] Any new dependencies have been added to the appropriate files.
- [ ] The changes do not introduce new issues or regressions.

### Screenshots or Visual Updates (if applicable)
*Before*
![image](https://github.com/user-attachments/assets/1fbf7ba3-c515-4c0a-8c0e-3469084c299c)

*After*
![image](https://github.com/user-attachments/assets/62fd17e2-b20d-452b-a896-4984dd6205c9)

