### PR TITLE
Add Brightedge and Intellimize Editor URLs to CSP allowed list

### DIFF
--- a/src/config/baseHeadTags.js
+++ b/src/config/baseHeadTags.js
@@ -17,6 +17,8 @@ const allowedUrls = [
   'https://117395157.intellimizeio.com',
   'https://api.intellimize.co',
   'https://log.intellimize.co',
+  'https://intellimizeditor.com',
+  'https://cdn.bc0a.com',
   'https://consent.trustarc.com',
   'https://*.trustarc.com'
 ];


### PR DESCRIPTION
Adds Brightedge (cdn.bc0a.com) and Intellimize Editor (intellimizeditor.com) to the allowed list in baseHeadTags.js.