### PR TITLE
change instances of "Vantage" to Teradata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ ftpub.sh
 .env
 *.backup
 *.syntax-backup
+.docusaurus/
+node_modules/
+static/

--- a/quickstarts/_partials/use-trials.mdx
+++ b/quickstarts/_partials/use-trials.mdx
@@ -1,2 +1,2 @@
 !!! note
-    You can now get a hosted instance of Vantage for free at [https://www.teradata.com/try](https://www.teradata.com/try).
+    You can now get a hosted instance of Teradata for free at [https://www.teradata.com/try](https://www.teradata.com/try).

--- a/quickstarts/analyze-data/integrate-teradata-with-knime.md
+++ b/quickstarts/analyze-data/integrate-teradata-with-knime.md
@@ -66,4 +66,4 @@ The DB Connector settings panel will appear on the right. Configure the followin
 This how-to demonstrats how to connect from KNIME Analytics Platform to Teradata.
 
 ## Further reading
-* [Train ML models in Vantage using only SQL](./ml.md)
+* [Train ML models in Teradata using only SQL](./ml.md)

--- a/quickstarts/connect-to-vantage/connect-teradata-dbeaver-okta-sso.md
+++ b/quickstarts/connect-to-vantage/connect-teradata-dbeaver-okta-sso.md
@@ -83,7 +83,7 @@ DBeaver is now able to connect to Teradata!
 
         ```bash
         ssh -i ~/.ssh/tunneluser_key.pem \
-          -L 1025:<VANTAGE-INTERNAL-IP>:1025 \
+          -L 1025:<Teradata-INTERNAL-IP>:1025 \
           -N <SSH-USER>@<JUMP-SERVER>
         ```
 
@@ -91,7 +91,7 @@ DBeaver is now able to connect to Teradata!
 
         ```bash
         ssh -i "$env:USERPROFILE\.ssh\tunneluser_key.pem" `
-          -L 1025:<VANTAGE-INTERNAL-IP>:1025 `
+          -L 1025:<TERADATA-INTERNAL-IP>:1025 `
           -N <SSH-USER>@<JUMP-SERVER>
         ```
 
@@ -103,7 +103,7 @@ DBeaver is now able to connect to Teradata!
         jdbc:teradata://127.0.0.1/LOGMECH=BROWSER,BROWSER_TAB_TIMEOUT=0
     ```
 
-    Your admin will provide the values for `<VANTAGE-INTERNAL-IP>`, `<SSH-USER>`, and `<JUMP-SERVER>`.
+    Your admin will provide the values for `<TERADATA-INTERNAL-IP>`, `<SSH-USER>`, and `<JUMP-SERVER>`.
 ## Running Teradata Queries in Dbeaver
 
 To begin querying:
@@ -220,4 +220,4 @@ To reassign keyboard shortcuts (e.g., run a query with `F5` instead of `Ctrl+Ent
 
 ## Summary
 
-This guide demonstrated how to connect to Teradata Vantage using browser-based SSO in DBeaver. This method enables secure enterprise login without manually entering credentials. It also provided recommended DBeaver settings to optimize the experience for Teradata users familiar with SQL Assistant.
+This guide demonstrated how to connect to Teradata using browser-based SSO in DBeaver. This method enables secure enterprise login without manually entering credentials. It also provided recommended DBeaver settings to optimize the experience for Teradata users familiar with SQL Assistant.

--- a/quickstarts/get-access-to-vantage/clearscape-analytics-experience/_index.md
+++ b/quickstarts/get-access-to-vantage/clearscape-analytics-experience/_index.md
@@ -4,4 +4,4 @@ ft:originId: clearscape-analytics-experience
 
 # Teradata Trial
 
-Get started with Teradata Trial, a free hosted environment for exploring Vantage capabilities.
+Get started with Teradata Trial, a free hosted environment for exploring Teradata capabilities.

--- a/quickstarts/get-access-to-vantage/on-your-cloud-infrastructure/_index.md
+++ b/quickstarts/get-access-to-vantage/on-your-cloud-infrastructure/_index.md
@@ -2,6 +2,6 @@
 ft:originId: on-your-cloud-infrastructure
 ---
 
-# Run Vantage on Your Cloud Infrastructure
+# Run Teradata on Your Cloud Infrastructure
 
 Deploy Vantage Express on AWS, Google Cloud, or Microsoft Azure.

--- a/quickstarts/get-access-to-vantage/on-your-local/_index.md
+++ b/quickstarts/get-access-to-vantage/on-your-local/_index.md
@@ -2,6 +2,6 @@
 ft:originId: on-your-local
 ---
 
-# Run Vantage on Your Local Machine
+# Run Teradata on Your Local Machine
 
 Run Vantage Express on your laptop using VMware, VirtualBox, or UTM.

--- a/quickstarts/manage-data/redis_streaming.md
+++ b/quickstarts/manage-data/redis_streaming.md
@@ -26,7 +26,7 @@ Teradata (event data storage)
 
 ## Prerequisites
 
-- Teradata Vantage instance with network access
+- Teradata instance with network access
 - Python 3.8+
 - `uv` (Python package manager - install from [uv.astral.sh](https://docs.astral.sh/uv/getting-started/))
 - Redis (Docker or local installation)

--- a/quickstarts/manage-data/terraform-airbyte-provider.md
+++ b/quickstarts/manage-data/terraform-airbyte-provider.md
@@ -111,7 +111,7 @@ provider "airbyte" {
   token_url     = var.airbyte_token_url
 }
 
-# Teradata Vantage Destination Configuration
+# Teradata Destination Configuration
 # For optional parameters visit https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_teradata 
 resource "airbyte_destination_teradata" "my_destination_teradata" {
   configuration = {
@@ -188,7 +188,7 @@ variable "workspace_id" {
     type = string
 }
 
-# Teradata Vantage connection credentials
+# Teradata connection credentials
 variable "host" {
   type = string
 }
@@ -220,7 +220,7 @@ airbyte_client_id     = "your-airbyte-client-id-here"
 airbyte_client_secret = "your-airbyte-client-secret-here"
 workspace_id = "your-workspace-id-here"
 
-# Teradata Vantage connection credentials
+# Teradata connection credentials
 host     = "your-teradata-host-here"
 username = "your-teradata-username-here"
 password = "your-teradata-password-here"


### PR DESCRIPTION
## Description
1. .gitignore — added .docusaurus/, node_modules/, and static/ to ignore list
2. use-trials.mdx — "hosted instance of Vantage" → "hosted instance of Teradata"
3. integrate-teradata-with-knime.md — "Train ML models in Vantage" → "Train ML models in Teradata"
4. connect-teradata-dbeaver-okta-sso.md — replaced <VANTAGE-INTERNAL-IP> placeholder references with <TERADATA-INTERNAL-IP> (x2), 
5. clearscape-analytics-experience/_index.md — "exploring Vantage capabilities" → "exploring Teradata capabilities"
6. on-your-cloud-infrastructure/_index.md — "Run Vantage on Your Cloud Infrastructure" → "Run Teradata on Your Cloud Infrastructure"
7. on-your-local/_index.md — "Run Vantage on Your Local Machine" → "Run Teradata on Your Local Machine"
8. redis_streaming.md — "Teradata Vantage instance" → "Teradata instance"
9. terraform-airbyte-provider.md — "Teradata Vantage Destination/connection" → "Teradata Destination/connection" (x3)